### PR TITLE
Update may2018

### DIFF
--- a/Obj2ObjMapBench/App.config
+++ b/Obj2ObjMapBench/App.config
@@ -1,6 +1,46 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.2.0" newVersion="1.2.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.DotNet.PlatformAbstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.4.0" newVersion="2.0.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.2.0" newVersion="1.4.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Obj2ObjMapBench/Benchmarks/AgileMapperBenchmark.cs
+++ b/Obj2ObjMapBench/Benchmarks/AgileMapperBenchmark.cs
@@ -1,0 +1,14 @@
+﻿using AgileObjects.AgileMapper.Extensions;
+
+namespace Obj2ObjMapBench
+{
+    public class AgileMapperBenchmark : BaseBenchmark
+    {
+
+
+        public override TDest Map<TSource, TDest>(TSource source)
+        {
+            return source.Map().ToANew<TDest>();
+        }
+    }
+}

--- a/Obj2ObjMapBench/Benchmarks/AutoMapperBenchmark.cs
+++ b/Obj2ObjMapBench/Benchmarks/AutoMapperBenchmark.cs
@@ -6,39 +6,22 @@ namespace Obj2ObjMapBench
 {
     public class AutoMapperBenchmark : BaseBenchmark
     {
+        private IMapper mapper;
+
         public AutoMapperBenchmark()
         {
-            Mapper.Initialize(cfg => {
-                cfg.CreateMap<SimplePoco, SimplePocoDTO>().IgnoreAllUnmappedProperties();
-                cfg.CreateMap<NestedPoco, NestedPocoDTO>().IgnoreAllUnmappedProperties();
+
+            MapperConfiguration config = new MapperConfiguration(cfg => {
+                cfg.CreateMap<SimplePoco, SimplePocoDTO>();
+                cfg.CreateMap<NestedPoco, NestedPocoDTO>();
             });
-            Mapper.Configuration.AssertConfigurationIsValid();
+
+            mapper = config.CreateMapper();
         }
 
         public override TDest Map<TSource, TDest>(TSource source)
         {
-            return Mapper.Map<TDest>(source);
-        }
-    }
-
-    public static class AutomapperExtensions
-    {
-        public static AutoMapper.IMappingExpression<TSource, TDest>
-            IgnoreAllUnmappedProperties<TSource, TDest>(
-                this AutoMapper.IMappingExpression<TSource, TDest> @this)
-        {
-
-            var sourceType = typeof(TSource);
-            var destinationType = typeof(TDest);
-            
-            var existingMaps = Mapper.Configuration.GetAllTypeMaps()
-                .First(x => x.SourceType.Equals(sourceType) &&
-                    x.DestinationType.Equals(destinationType));
-
-            foreach (var prop in existingMaps.GetUnmappedPropertyNames())
-                @this.ForMember(prop, x => x.Ignore());
-
-            return @this;
+            return mapper.Map<TDest>(source);
         }
 
     }

--- a/Obj2ObjMapBench/Benchmarks/ExpressMapperBenchmark.cs
+++ b/Obj2ObjMapBench/Benchmarks/ExpressMapperBenchmark.cs
@@ -1,0 +1,27 @@
+﻿using ExpressMapper;
+using ExpressMapper.Extensions;
+using Obj2ObjMapBench.Models;
+
+
+namespace Obj2ObjMapBench
+{
+    public class ExpressMapperBenchmark : BaseBenchmark
+    {
+        public ExpressMapperBenchmark()
+        {
+            Mapper.Register<SimplePoco, SimplePocoDTO>();
+            Mapper.Register<NestedPoco, NestedPocoDTO>();
+            Mapper.Compile();
+
+        }
+
+        public override TDest Map<TSource, TDest>(TSource source)
+        {
+            if (source is SimplePoco)
+                return (source as SimplePoco).Map<SimplePoco, SimplePocoDTO>() as TDest;
+
+            return (source as NestedPoco).Map<NestedPoco, NestedPocoDTO>() as TDest;
+
+        }
+    }
+}

--- a/Obj2ObjMapBench/Benchmarks/HandwrittenBenchmark.cs
+++ b/Obj2ObjMapBench/Benchmarks/HandwrittenBenchmark.cs
@@ -1,6 +1,7 @@
-﻿using Obj2ObjMapBench.Models;
+﻿using ExpressMapper.Extensions;
+using Obj2ObjMapBench.Models;
 using System;
-using System.Collections.Generic;
+
 
 namespace Obj2ObjMapBench
 {

--- a/Obj2ObjMapBench/Benchmarks/MapsterBenchmark.cs
+++ b/Obj2ObjMapBench/Benchmarks/MapsterBenchmark.cs
@@ -1,0 +1,14 @@
+﻿
+using Mapster;
+
+
+namespace Obj2ObjMapBench
+{
+    public class MapsterBenchmark : BaseBenchmark
+    {
+        public override TDest Map<TSource, TDest>(TSource source)
+        {
+            return source.Adapt<TDest>();
+        }
+    }
+}

--- a/Obj2ObjMapBench/Obj2ObjMapBench.csproj
+++ b/Obj2ObjMapBench/Obj2ObjMapBench.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Obj2ObjMapBench</RootNamespace>
     <AssemblyName>Obj2ObjMapBench</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,9 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=5.0.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.5.0.0-beta-1\lib\net45\AutoMapper.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AgileObjects.AgileMapper, Version=0.23.2.0, Culture=neutral, PublicKeyToken=40b730fcfbe52fee, processorArchitecture=MSIL">
+      <HintPath>..\packages\AgileObjects.AgileMapper.0.23.2\lib\net40\AgileObjects.AgileMapper.dll</HintPath>
+    </Reference>
+    <Reference Include="AgileObjects.NetStandardPolyfills, Version=1.3.0.0, Culture=neutral, PublicKeyToken=06131ac1c008ad4e, processorArchitecture=MSIL">
+      <HintPath>..\packages\AgileObjects.NetStandardPolyfills.1.3.0\lib\net40\AgileObjects.NetStandardPolyfills.dll</HintPath>
+    </Reference>
+    <Reference Include="AgileObjects.ReadableExpressions, Version=1.11.0.0, Culture=neutral, PublicKeyToken=9f54ad81db69da8e, processorArchitecture=MSIL">
+      <HintPath>..\packages\AgileObjects.ReadableExpressions.1.11.0\lib\net40\AgileObjects.ReadableExpressions.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoMapper, Version=6.2.2.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.6.2.2\lib\net45\AutoMapper.dll</HintPath>
     </Reference>
     <Reference Include="AutoPoco, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoPocoBeta.1.2.0\lib\AutoPoco.dll</HintPath>
@@ -45,38 +54,186 @@
       <HintPath>..\packages\AutoPoco.DataSources.1.0.42\lib\AutoPoco.DataSources.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="BenchmarkDotNet, Version=0.9.7.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
-      <HintPath>..\packages\BenchmarkDotNet.0.9.7\lib\net40\BenchmarkDotNet.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="BenchmarkDotNet, Version=0.10.14.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.0.10.14\lib\net46\BenchmarkDotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="BenchmarkDotNet.Core, Version=0.10.14.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.Core.0.10.14\lib\net46\BenchmarkDotNet.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="BenchmarkDotNet.Toolchains.Roslyn, Version=0.10.14.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.Toolchains.Roslyn.0.10.14\lib\net46\BenchmarkDotNet.Toolchains.Roslyn.dll</HintPath>
     </Reference>
     <Reference Include="EmitMapper, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EmitMapper.1.0.0\lib\EmitMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="ExpressMapper, Version=1.9.1.0, Culture=neutral, PublicKeyToken=ac363faa09311ba0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Expressmapper.1.9.1\lib\net46\ExpressMapper.dll</HintPath>
+    </Reference>
+    <Reference Include="Mapster, Version=3.1.8.0, Culture=neutral, PublicKeyToken=2f39883af23c29a8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mapster.3.1.8\lib\net45\Mapster.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.2.8.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.2.8.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.DotNet.InternalAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.DotNet.InternalAbstractions.1.0.0\lib\net451\Microsoft.DotNet.InternalAbstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.0.4\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.4.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
+    </Reference>
     <Reference Include="Omu.ValueInjecter, Version=3.1.1.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
-      <HintPath>..\packages\valueinjecter.3.1.1.2\lib\net40\Omu.ValueInjecter.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\ValueInjecter.3.1.1.5\lib\net40\Omu.ValueInjecter.dll</HintPath>
+    </Reference>
+    <Reference Include="OoMapper, Version=0.2.0.33, Culture=neutral, PublicKeyToken=889bb259bb1214bf, processorArchitecture=MSIL">
+      <HintPath>..\packages\OoMapper.0.2.0.33\lib\net4\OoMapper.dll</HintPath>
     </Reference>
     <Reference Include="SafeMapper, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eb6e5d6cfb80aac2, processorArchitecture=MSIL">
       <HintPath>..\packages\SafeMapper.2.0.120\lib\net45\SafeMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net463\System.AppContext.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.4.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console">
+      <HintPath>..\packages\System.Console.4.3.1\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.FileVersionInfo">
+      <HintPath>..\packages\System.Diagnostics.FileVersionInfo.4.3.0\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Diagnostics.StackTrace">
+      <HintPath>..\packages\System.Diagnostics.StackTrace.4.3.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq">
+      <HintPath>..\packages\System.Linq.4.3.0\lib\net463\System.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq.Expressions">
+      <HintPath>..\packages\System.Linq.Expressions.4.3.0\lib\net463\System.Linq.Expressions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Management" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Reflection">
+      <HintPath>..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.5.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions">
+      <HintPath>..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices">
+      <HintPath>..\packages\System.Runtime.InteropServices.4.3.0\lib\net463\System.Runtime.InteropServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.4.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.4.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.4.4.0\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.4.0\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread">
+      <HintPath>..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.ReaderWriter">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.1\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.XmlDocument">
+      <HintPath>..\packages\System.Xml.XmlDocument.4.3.0\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.XPath">
+      <HintPath>..\packages\System.Xml.XPath.4.3.0\lib\net46\System.Xml.XPath.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.XPath.XDocument">
+      <HintPath>..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="TinyMapper, Version=2.0.0.40, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\TinyMapper.2.0.8\lib\net45\TinyMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Benchmarks\AgileMapperBenchmark.cs" />
     <Compile Include="Benchmarks\EmitMapperBenchmark.cs" />
+    <Compile Include="Benchmarks\ExpressMapperBenchmark.cs" />
+    <Compile Include="Benchmarks\MapsterBenchmark.cs" />
     <Compile Include="Benchmarks\ValueInjecterBenchmark.cs" />
     <Compile Include="Benchmarks\SafeMapperBenchmark.cs" />
     <Compile Include="Benchmarks\TinyMapperBenchmark.cs" />
@@ -93,7 +250,10 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Obj2ObjMapBench/Program.cs
+++ b/Obj2ObjMapBench/Program.cs
@@ -3,10 +3,7 @@ using BenchmarkDotNet.Running;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Text;
-using BenchmarkDotNet.Extensions;
-using BenchmarkDotNet.Horology;
+
 
 namespace Obj2ObjMapBench
 {
@@ -21,11 +18,15 @@ namespace Obj2ObjMapBench
 
             var benchmarksToRun = new Dictionary<string, Type>();
             benchmarksToRun.Add("Handwritten", typeof(HandwrittenBenchmark));
+            benchmarksToRun.Add("AgileMapperBenchmark", typeof(AgileMapperBenchmark));
             benchmarksToRun.Add("AutoMapperBenchmark", typeof(AutoMapperBenchmark));
+            benchmarksToRun.Add("EmitMapperBenchmark", typeof(EmitMapperBenchmark));
+            //benchmarksToRun.Add("ExpressMapper", typeof(ExpressMapperBenchmark));
+            benchmarksToRun.Add("MapsterBenchmark", typeof(MapsterBenchmark));
             //benchmarksToRun.Add("TinyMapperBenchmark", typeof(TinyMapperBenchmark));
             benchmarksToRun.Add("SafeMapperBenchmark", typeof(SafeMapperBenchmark));
             benchmarksToRun.Add("ValueInjecterBenchmark", typeof(ValueInjecterBenchmark));
-            benchmarksToRun.Add("EmitMapperBenchmark", typeof(EmitMapperBenchmark));
+
 
             var summaries = new List<Summary>();
             foreach (var item in benchmarksToRun)

--- a/Obj2ObjMapBench/packages.config
+++ b/Obj2ObjMapBench/packages.config
@@ -1,12 +1,71 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="5.0.0-beta-1" targetFramework="net452" />
+  <package id="AgileObjects.AgileMapper" version="0.23.2" targetFramework="net471" />
+  <package id="AgileObjects.NetStandardPolyfills" version="1.3.0" targetFramework="net471" />
+  <package id="AgileObjects.ReadableExpressions" version="1.11.0" targetFramework="net471" />
+  <package id="AutoMapper" version="6.2.2" targetFramework="net452" />
   <package id="AutoPoco" version="1.0.0.0" targetFramework="net452" />
   <package id="AutoPoco.DataSources" version="1.0.42" targetFramework="net452" />
   <package id="AutoPocoBeta" version="1.2.0" targetFramework="net452" />
-  <package id="BenchmarkDotNet" version="0.9.7" targetFramework="net452" />
+  <package id="BenchmarkDotNet" version="0.10.14" targetFramework="net471" />
+  <package id="BenchmarkDotNet.Core" version="0.10.14" targetFramework="net471" />
+  <package id="BenchmarkDotNet.Toolchains.Roslyn" version="0.10.14" targetFramework="net471" />
   <package id="EmitMapper" version="1.0.0" targetFramework="net452" />
+  <package id="Expressmapper" version="1.9.1" targetFramework="net471" />
+  <package id="Mapster" version="3.1.8" targetFramework="net471" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="2.6.0" targetFramework="net471" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.8.0" targetFramework="net471" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.0" targetFramework="net471" />
+  <package id="Microsoft.DotNet.InternalAbstractions" version="1.0.0" targetFramework="net471" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.0.4" targetFramework="net471" />
+  <package id="Microsoft.Win32.Registry" version="4.4.0" targetFramework="net471" />
+  <package id="OoMapper" version="0.2.0.33" targetFramework="net471" />
   <package id="SafeMapper" version="2.0.120" targetFramework="net452" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net471" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net471" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net471" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net471" />
+  <package id="System.Console" version="4.3.1" targetFramework="net471" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net471" />
+  <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net471" />
+  <package id="System.Diagnostics.StackTrace" version="4.3.0" targetFramework="net471" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net471" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net471" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net471" />
+  <package id="System.IO" version="4.3.0" targetFramework="net471" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net471" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net471" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net471" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net471" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net471" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net471" />
+  <package id="System.Reflection.Metadata" version="1.5.0" targetFramework="net471" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net471" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net471" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net471" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net471" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net471" />
+  <package id="System.Security.AccessControl" version="4.4.0" targetFramework="net471" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net471" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net471" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net471" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net471" />
+  <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net471" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net471" />
+  <package id="System.Text.Encoding.CodePages" version="4.4.0" targetFramework="net471" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net471" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net471" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net471" />
+  <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net471" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net471" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net471" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net471" />
+  <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net471" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net471" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net471" />
+  <package id="System.Xml.XmlSerializer" version="4.3.0" targetFramework="net471" />
+  <package id="System.Xml.XPath" version="4.3.0" targetFramework="net471" />
+  <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net471" />
   <package id="TinyMapper" version="2.0.8" targetFramework="net452" />
-  <package id="valueinjecter" version="3.1.1.2" targetFramework="net452" />
+  <package id="ValueInjecter" version="3.1.1.5" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -6,40 +6,47 @@ The purpose is not to compare the functionalities between them. Only to see how 
 ## Benchmarked Mappers
 All of the below mappers where included in the project using the respective NuGet packages.
 
-* AutoMapper 4.2.1
+* AgileMapper 0.23.2
+* AutoMapper 6.2.2
 * EmitMapper 1.0.0
+* ExpressMapper 1.9.1 (failled on Nested Object :/)
+* Mapster 3.1.8
 * SafeMapper 2.0.118
-* TinyMapper 2.0.8
-* ValueInjecter 3.1.1.2
+* ValueInjecter 3.1.1.5
 
 ## Latest Results
 
 **System specs**
 ```
-BenchmarkDotNet=v0.9.1.0
-OS=Microsoft Windows NT 6.2.9200.0
-Processor=Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz, ProcessorCount=4
-Frequency=2742184 ticks, Resolution=364.6728 ns
-HostCLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
+BenchmarkDotNet=v0.10.14, OS=Windows 10.0.16299.402 (1709/FallCreatorsUpdate/Redstone3)
+Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
+Frequency=3914059 Hz, Resolution=255.4893 ns, Timer=TSC
+  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2633.0
 ```
 
 **Simple object (10.000 instances)**
 
 | Mapper | Median | StdDev |
 | --- | ---: | ---: |
-| Handwritten | 1.6221 ms | 0.0713 ms |
-| SafeMapper | 1.7654 ms | 0.2783 ms |
-| EmitMapper | 1.8554 ms | 0.1163 ms |
-| TinyMapper | 2.0483 ms | 0.0406 ms |
-| ValueInjecter | 66.6965 ms | 2.7518 ms |
-| AutoMapper | 93.6690 ms | 11.5649 ms |
+| Handwritten | 0.6064 ms | 0.0050 ms |
+| SafeMapper | 0.6231 ms | 0.0317 ms |
+| EmitMapper | 0.7815 ms | 0.0072 ms |
+| Mapster | 2.571 ms | 0.0304 ms |
+| AgileMapper | 3.394 ms | 0.0320 ms |
+| AutoMapper | 3.592 ms |  0.1256 ms |
+| ValueInjecter | 55.35 ms | 0.4637 ms |
+
 
 **Nested objects  (10.000 instances)**
 
 |    Mapper |    Median |    StdDev |
 |---------- |----------: |----------: | 
-| Handwritten | 1.6206 ms | 0.0364 ms |
-| SafeMapper | 1.8354 ms | 0.0712 ms |
-| EmitMapper | 1.9330 ms | 0.2161 ms |
-| ValueInjecter | 74.4472 ms | 3.7340 ms |
-| AutoMapper | 160.3249 ms |  6.4109 ms |
+| Handwritten | 0.6364 ms | 0.0034 ms |
+| SafeMapper | 0.6481 ms | 0.0042 ms |
+| EmitMapper | 0.8443 ms | 0.0069 ms |
+| AgileMapper | 3.394 ms | 0.0320 ms |
+| AutoMapper |  4.990 ms |   0.0367 ms |
+| ValueInjecter | 60.31 ms | 0.3498 ms |
+| Mapster | 115.068 ms | 0.8521 ms |
+| AgileMapper | 128.835 ms | 3.8260 ms |
+


### PR DESCRIPTION
Update to latest O2O Mapper library versions using NuGet and Add new candidates: AgileMapper, Mapster ( and an attempt to use ExpressMapper) . Starting to remove TinyMapper (still ref but removed from ReadMe.md)

Update .net Version from 4.5.2 to 4.7.1
Upgrade solution file to VS2017
Update nuget Package :
	AutoMapper 6.2.2 - convert deprecated static method - not sure if unmapped property is well handled by default as intended
	BenchmarkDotNet 0.10.14
	ValueInjecter 3.1.1.5
Add new Mappers to Benchmark :
	AgileMapper 0.23.2
	ExpressMapper 1.9.1 (failled on Nested Object :/)
	Mapster 3.1.8